### PR TITLE
Remove s3 data

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
   user_names_map = {
     for user, val in var.sftp_users :
     user => merge(val, {
-      s3_bucket_arn = "${local.s3_arn_prefix}${lookup(val, "s3_bucket_name")}"
+      s3_bucket_arn = "${local.s3_arn_prefix}${var.s3_bucket_name}"
     })
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -10,19 +10,13 @@ locals {
   user_names_map = {
     for user, val in var.sftp_users :
     user => merge(val, {
-      s3_bucket_arn = lookup(val, "s3_bucket_name", null) != null ? "${local.s3_arn_prefix}${lookup(val, "s3_bucket_name")}" : one(data.aws_s3_bucket.landing[*].arn)
+      s3_bucket_arn = "${local.s3_arn_prefix}${lookup(val, "s3_bucket_name")}"
     })
   }
 }
 
 data "aws_partition" "default" {
   count = local.enabled ? 1 : 0
-}
-
-data "aws_s3_bucket" "landing" {
-  count = local.enabled ? 1 : 0
-
-  bucket = var.s3_bucket_name
 }
 
 resource "aws_transfer_server" "default" {

--- a/main.tf
+++ b/main.tf
@@ -59,10 +59,10 @@ resource "aws_transfer_user" "default" {
     for_each = var.restricted_home ? (
       lookup(each.value, "home_directory_mappings", null) != null ? lookup(each.value, "home_directory_mappings") : [
         {
-          entry = "/"
+          entry = "/",
           # Specifically do not use $${Transfer:UserName} since subsequent terraform plan/applies will try to revert
           # the value back to $${Tranfer:*} value
-          target = format("/%s/%s", lookup(each.value, "s3_bucket_name", var.s3_bucket_name), each.value.user_name)
+          target = target = format("/%s%s", lookup(each.value, "s3_bucket_name", var.s3_bucket_name), each.value.home_directory_target)
         }
       ]
     ) : toset([])
@@ -164,7 +164,7 @@ data "aws_iam_policy_document" "s3_access_for_sftp_users" {
     ]
 
     resources = [
-      var.restricted_home ? "${each.value.s3_bucket_arn}/${each.value.user_name}/*" : "${each.value.s3_bucket_arn}/*"
+      var.restricted_home ? "${each.value.s3_bucket_arn}${each.value.home_directory_target}/*" : "${each.value.s3_bucket_arn}/*"
     ]
   }
 }


### PR DESCRIPTION
## what
* removed s3 data resources in lieu of just using an variable to pass in an arn. 
* Added the ability to pass in a home_directory in the sftp_user map

## why
* This will ensure ease of use with resources in multiple regions.
* Allows for better customization of sftp users

